### PR TITLE
Add docker-compose with Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ $ yarn run start:dev
 $ yarn run start:prod
 ```
 
+## Local infrastructure
+
+This project includes a `docker-compose.yml` file for running a PostgreSQL
+database locally. Start the services with:
+
+```bash
+$ docker-compose up -d
+```
+
+The database is exposed on `localhost:5432` with the default `postgres`
+username and password.
+
 ## Run tests
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:17-bookworm
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with PostgreSQL service
- document local infrastructure setup in README

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68444fb3b9dc83308bfb8c63fb6823ef